### PR TITLE
Add README and docc comments

### DIFF
--- a/Applets/ExampleApplet/Sources/ExampleApplet/ExampleApplet.swift
+++ b/Applets/ExampleApplet/Sources/ExampleApplet/ExampleApplet.swift
@@ -1,11 +1,22 @@
 import Applet
 
+/// A simple example applet demonstrating basic functionality and structure.
+///
+/// This applet serves as a basic template and starting point. Developers can either
+/// modify this applet directly or remove it and create their own applets by conforming
+/// to the `Applet` protocol.
+///
+/// To replace this example:
+/// 1. Delete the `Applets/ExampleApplet` directory.
+/// 2. Remove the dependency on "ExampleApplet" from the main `Package.swift` file.
+/// 3. Remove `ExampleApplet()` instantiation from `AppletKitView.swift` (or your custom root view).
 public struct ExampleApplet: Applet {
-    public let id: String = "hello.world"
-    public let title: String = "Hello World"
+    public let id: String = "example.applet"
+    public let title: String = "Example Applet"
 
     public init() { }
 
+    /// The content view for this applet.
     public var body: some View {
         ExampleAppletRootView()
     }

--- a/Applets/ExampleApplet/Sources/ExampleApplet/ExampleAppletRootView.swift
+++ b/Applets/ExampleApplet/Sources/ExampleApplet/ExampleAppletRootView.swift
@@ -1,7 +1,24 @@
 import AppletUI
 import ExampleAppletInterface
 
+/// The root view for the `ExampleApplet`.
+///
+/// This view demonstrates a basic UI structure within an applet. It displays a title,
+/// a piece of text from a shared application state (`ExampleAppletState`), and a button
+/// that updates this shared state.
+///
+/// This `ExampleAppletRootView` is specific to `ExampleApplet`. When creating your own
+/// applets, you will design your own root views with the necessary UI and logic.
 struct ExampleAppletRootView: View {
+    /// Accesses and allows modification of `ExampleAppletState`.
+    /// `ExampleAppletState` itself is defined in the `ExampleAppletInterface` module
+    /// (see `Applets/ExampleApplet/Sources/ExampleAppletInterface/ExampleAppletState.swift`).
+    /// The `@AppState` property wrapper and the system for registering state (e.g., `Application.exampleAppletState`,
+    /// likely found in `Application+ExampleApplet.swift` in the interface module) are provided by `Core/AppState`.
+    /// This setup allows different applets to interact with the same data.
+    ///
+    /// In a real application, you would define your own state objects relevant to your app's features,
+    /// typically in their own interface modules, and register them with the `AppState` system.
     @AppState(\.exampleAppletState) private var exampleAppletState: ExampleAppletState
 
     var body: some View {
@@ -12,6 +29,8 @@ struct ExampleAppletRootView: View {
 
             Spacer()
 
+            // Displays the `exampleValue` from the shared `exampleAppletState`.
+            // This demonstrates how an applet can read from shared state.
             Text(exampleAppletState.exampleValue)
                 .font(.title3)
                 .padding()
@@ -19,9 +38,11 @@ struct ExampleAppletRootView: View {
             Spacer()
         }
         .safeAreaInset(edge: .bottom) {
-            Button("Update") {
+            // This button demonstrates how an applet can modify shared state.
+            // Pressing it updates `exampleAppletState.exampleValue` with the current time.
+            Button("Update Shared State (from ExampleApplet)") {
                 let formattedTime: String = Date.now.formatted(date: .omitted, time: .standard)
-                exampleAppletState.exampleValue = "Hello, \(formattedTime)!"
+                exampleAppletState.exampleValue = "Updated by ExampleApplet at \(formattedTime)"
             }
             .padding(.bottom, 32)
         }
@@ -29,5 +50,10 @@ struct ExampleAppletRootView: View {
 }
 
 #Preview {
+    // It's good practice to provide a preview for your applet's root view
+    // to facilitate design and development.
     ExampleAppletRootView()
+        // For previewing state-dependent views, you might need to mock or provide
+        // initial state if AppState isn't configured globally for previews.
+        // .environmentObject(MockAppState()) // Example if AppState was an EnvironmentObject
 }

--- a/Applets/ExampleAppletInteroperability/Sources/ExampleAppletInteroperability/ExampleAppletInteroperability.swift
+++ b/Applets/ExampleAppletInteroperability/Sources/ExampleAppletInteroperability/ExampleAppletInteroperability.swift
@@ -1,11 +1,22 @@
 import Applet
 
+/// An example applet demonstrating how different applets can interact with shared application state.
+///
+/// This applet, much like `ExampleApplet`, modifies `ExampleAppletState`. Its primary purpose
+/// is to show that changes made by one applet can be observed by another, and that multiple
+/// applets can contribute to and read from a common state pool.
+///
+/// To replace or remove this example:
+/// 1. Delete the `Applets/ExampleAppletInteroperability` directory.
+/// 2. Remove the dependency on "ExampleAppletInteroperability" from the main `Package.swift` file.
+/// 3. Remove `ExampleAppletInteroperability()` instantiation from `AppletKitView.swift` (or your custom root view).
 public struct ExampleAppletInteroperability: Applet {
-    public let id: String = "hello.world.interoperability"
-    public let title: String = "Hello World Example Interoperability"
+    public let id: String = "example.applet.interoperability"
+    public let title: String = "Example Interoperability"
 
     public init() { }
 
+    /// The content view for this applet.
     public var body: some View {
         ExampleAppletInteroperabilityRootView()
     }

--- a/Applets/ExampleAppletInteroperability/Sources/ExampleAppletInteroperability/ExampleAppletInteroperabilityRootView.swift
+++ b/Applets/ExampleAppletInteroperability/Sources/ExampleAppletInteroperability/ExampleAppletInteroperabilityRootView.swift
@@ -1,7 +1,18 @@
 import AppletUI
 import ExampleAppletInterface
 
+/// The root view for the `ExampleAppletInteroperability`.
+///
+/// This view is very similar to `ExampleAppletRootView`. It also interacts with
+/// the shared `ExampleAppletState` to demonstrate that multiple, independent applets
+/// can read from and write to the same piece of application state.
+///
+/// When forking this repository, you would replace this with the specific UI for
+/// your own applet that might need to interoperate with others.
 struct ExampleAppletInteroperabilityRootView: View {
+    /// Accesses the same shared `ExampleAppletState` as `ExampleApplet`.
+    /// This allows `ExampleAppletInteroperability` to see changes made by `ExampleApplet`
+    /// and vice-versa.
     @AppState(\.exampleAppletState) private var exampleAppletState: ExampleAppletState
 
     var body: some View {
@@ -12,6 +23,8 @@ struct ExampleAppletInteroperabilityRootView: View {
 
             Spacer()
 
+            // Displays the `exampleValue` from `exampleAppletState`.
+            // This value could have been set by this applet or by `ExampleApplet`.
             Text(exampleAppletState.exampleValue)
                 .font(.title3)
                 .padding()
@@ -19,9 +32,11 @@ struct ExampleAppletInteroperabilityRootView: View {
             Spacer()
         }
         .safeAreaInset(edge: .bottom) {
-            Button("Update") {
+            // This button updates the shared state, specifically indicating that
+            // the update originated from `ExampleAppletInteroperability`.
+            Button("Update Shared State (from Interoperability)") {
                 let formattedTime: String = Date.now.formatted(date: .omitted, time: .standard)
-                exampleAppletState.exampleValue = "Hello, \(formattedTime)! (ExampleAppletInteroperability)"
+                exampleAppletState.exampleValue = "Updated by InteropApplet at \(formattedTime)"
             }
             .padding(.bottom, 32)
         }
@@ -30,4 +45,5 @@ struct ExampleAppletInteroperabilityRootView: View {
 
 #Preview {
     ExampleAppletInteroperabilityRootView()
+    // As with ExampleAppletRootView, consider mocking state for previews if necessary.
 }

--- a/Core/AppletNavigation/Sources/AppletNavigation/AppletNavigation.swift
+++ b/Core/AppletNavigation/Sources/AppletNavigation/AppletNavigation.swift
@@ -1,17 +1,58 @@
 import AppState
 import SwiftUI
 
-// MARK: - TODO: Sample code
+// MARK: - Example Navigation State (AppletTab)
 
-public enum AppletTab: String, Sendable {
+/// Represents the different tabs available in the example `AppletKitView`'s `TabView`.
+///
+/// This enum is used in conjunction with `@AppState(\.tab)` to manage the currently
+/// selected tab in the example UI.
+///
+/// ## Customizing Navigation
+///
+/// If you replace the `TabView` in `AppletKitView` with a different navigation model
+/// (e.g., `NavigationView`, a custom sidebar, programmatic navigation), you will likely
+/// need to:
+///
+/// 1.  **Modify or Replace `AppletTab`**:
+///     *   If your navigation still uses distinct "tabs" or sections but with different names
+///       or more options, you can modify the cases of this enum.
+///     *   If your navigation is fundamentally different (e.g., hierarchical, path-based),
+///       you might replace `AppletTab` entirely with a new enum, struct, or other type
+///       that better represents your navigation state.
+///
+/// 2.  **Update `AppState` Extension**:
+///     The extension `Application.tab` below registers `AppletTab` with `AppState`.
+///     If you change `AppletTab` or replace it, you'll need to update this extension
+///     accordingly to reflect your new navigation state type and its initial value.
+///
+/// 3.  **Update `AppletKitView`**:
+///     Ensure `AppletKitView` (or your custom root view) uses your new navigation
+///     state type to drive its UI.
+///
+/// For example, if you switch to a `NavigationView` where you can navigate to various
+/// screens, your navigation state might be an optional enum representing the current screen,
+/// or a navigation path.
+public enum AppletTab: String, Sendable, CaseIterable { // CaseIterable for potential dynamic tab creation
     case home
     case settings
+    // Add more cases here if you extend the TabView
+    // e.g., case profile, case search
 }
 
 extension Application {
+    /// Provides access to the current `AppletTab` state within the application.
+    ///
+    /// This is used by `AppletKitView`'s `TabView` to bind its selection.
+    /// The `initial: .home` sets the default tab when the application starts.
+    ///
+    /// If you customize `AppletTab` (e.g., rename it, change its cases, or use a different
+    /// type for navigation state), you must update this computed property:
+    /// - Change `State<AppletTab>` to `State<YourNavigationStateType>`.
+    /// - Update `initial:` to an appropriate default value for your new navigation state.
     public var tab: State<AppletTab> {
-        state(initial: .home)
+        state(initial: .home) // Sets '.home' as the default selected tab.
     }
 }
 
-// MARK: END: Sample code -
+// MARK: END: Example Navigation State -

--- a/README.md
+++ b/README.md
@@ -1,0 +1,165 @@
+# AppletKit: A Modular Swift App Framework
+
+AppletKit is a Swift-based framework designed to provide a modular architecture for building applications. It allows developers to create independent "applets" that can be easily managed and integrated into a main application shell. This repository serves as a template and a starting point for developers looking to build their own applications using this paradigm.
+
+## Getting Started
+
+This project is structured as a Swift Package. You can open and run it using Xcode.
+
+1.  Clone the repository:
+    ```bash
+    git clone <repository-url>
+    ```
+2.  Open `Package.swift` in Xcode.
+3.  Select a target (e.g., an iOS simulator or device) and run the project.
+
+This will launch the example application, which includes a `TabView` hosting two sample applets: `ExampleApplet` and `ExampleAppletInteroperability`.
+
+## Project Structure
+
+The project is organized into several key directories:
+
+*   **`Sources/AppletKit`**: Contains the main `AppletKitView.swift`, which is the entry point UI for the framework. This view typically hosts the navigation structure (e.g., a `TabView`) for the different applets.
+*   **`Applets/`**: This directory houses individual applets. Each applet is its own Swift Package.
+    *   **`ExampleApplet/`**: A sample applet demonstrating basic functionality and UI.
+    *   **`ExampleAppletInteroperability/`**: Another sample applet that shows how applets can share and interact with common application state.
+*   **`Core/`**: Contains core modules used across the framework and potentially by individual applets.
+    *   **`Applet/`**: Defines the `Applet` protocol and related structures that applets conform to.
+    *   **`AppletNavigation/`**: Includes navigation-related code, such as the `AppletTab` enum used by the example `AppletKitView` for tab-based navigation.
+    *   **`AppletUI/`**: (e.g., `Core/AppletUI`) Contains shared UI components or styling. Notably, this module also re-exports `AppState` and `SwiftUI` (via `@_exported import`), making their symbols available to any file that imports `AppletUI`.
+    *   **`AppState/`**: (e.g., `Core/AppState`) Provides the `@AppState` property wrapper and the mechanism for managing shared application state that applets can access and modify. The actual state objects (like `ExampleAppletState`) might be defined in interface packages alongside the applets that use them (e.g., `Applets/ExampleApplet/Sources/ExampleAppletInterface/`).
+
+## Forking and Customizing This Repository
+
+This repository is designed to be forked and adapted for your own application needs. Here’s how you can customize it:
+
+### 1. Replacing Example Applets
+
+The provided `ExampleApplet` and `ExampleAppletInteroperability` are placeholders. To create your own application:
+
+1.  **Remove or Modify Example Applets**:
+    *   You can delete the directories `Applets/ExampleApplet` and `Applets/ExampleAppletInteroperability`.
+    *   Alternatively, you can modify their content to build your first applet.
+2.  **Create Your Own Applets**:
+    *   It's recommended to create a new Swift Package for each new applet within the `Applets/` directory.
+    *   Each applet should define a struct that conforms to the `Applet` protocol (defined in `Core/Applet`). This typically involves specifying an `id`, `title`, and a `body` (which is a SwiftUI `View`).
+    ```swift
+    // Example: Applets/YourApplet/Sources/YourApplet/YourApplet.swift
+    import Applet
+    import SwiftUI
+
+    public struct YourApplet: Applet {
+        public let id: String = "your.applet.id"
+        public let title: String = "My Custom Applet"
+
+        public init() { }
+
+        public var body: some View {
+            YourAppletRootView() // Your applet's main view
+        }
+    }
+    ```
+3.  **Update Dependencies**:
+    *   In the main `Package.swift` (at the root of the repository), remove the dependencies on the example applets and add dependencies to your new applets.
+    ```swift
+    // In Package.swift
+    dependencies: [
+        // .package(path: "Applets/ExampleApplet"), // Remove or comment out
+        // .package(path: "Applets/ExampleAppletInteroperability"), // Remove or comment out
+        .package(path: "Applets/YourApplet"), // Add your applet
+    ],
+    targets: [
+        .target(
+            name: "AppletKit",
+            dependencies: [
+                // "ExampleApplet", // Remove
+                // "ExampleAppletInteroperability", // Remove
+                "YourApplet", // Add your applet
+            ],
+            // ...
+        ),
+        // ...
+    ]
+    ```
+
+### 2. Customizing Navigation and `AppletKitView`
+
+The default `AppletKitView.swift` uses a `TabView`. You might want a different navigation structure (e.g., a list, side menu, or no explicit chrome if integrating into a larger app).
+
+1.  **Modify `AppletKitView.swift`**:
+    *   Open `Sources/AppletKit/AppletKit.swift`.
+    *   Change the `TabView` to your desired navigation structure.
+    *   Instantiate your custom applets within this view.
+    ```swift
+    // Example: Modifying AppletKitView.swift
+    import SwiftUI
+    import YourApplet // Import your applet
+
+    public struct AppletKitView: View {
+        // Manage navigation state as needed
+        // @State private var selection: YourNavigationEnum = .initialScreen
+
+        public var body: some View {
+            // Replace TabView with your custom navigation
+            NavigationView {
+                List {
+                    NavigationLink("Open My Applet", destination: YourApplet())
+                    // Add other navigation links or views
+                }
+            }
+            // Or simply:
+            // YourApplet() // If AppletKitView is just a container for one applet
+        }
+    }
+    ```
+
+2.  **Adapt `AppletNavigation`**:
+    *   The `Core/AppletNavigation/AppletNavigation.swift` file contains `AppletTab`, which is specific to the example `TabView`.
+    *   If you change the navigation, you might need to modify or replace this enum with your own navigation state management.
+    *   Ensure your `AppletKitView` and any navigation controls correctly use your new navigation state.
+
+### 3. Integrating into Your Existing Application
+
+If you have an existing application and want to use `AppletKit` to manage parts of it:
+
+1.  **Add `AppletKit` as a Package Dependency**:
+    *   In your existing app's Xcode project, add `AppletKit` as a Swift Package dependency, pointing to your forked repository.
+2.  **Instantiate `AppletKitView`**:
+    *   In your app's UI hierarchy (e.g., within a `ContentView` or another view), instantiate `AppletKitView`.
+    ```swift
+    // In your app's ContentView.swift
+    import SwiftUI
+    import AppletKit // Assuming your forked package is named AppletKit
+
+    struct ContentView: View {
+        var body: some View {
+            // Your existing app UI
+            // ...
+
+            // Integrate AppletKitView where appropriate
+            AppletKitView()
+                .frame(height: 300) // Example: Embed it in a part of your UI
+        }
+    }
+    ```
+    *   You might not even use the provided `AppletKitView` directly. Instead, you could instantiate your applets directly within your app's views if `AppletKitView`'s structure doesn't fit. The primary benefit comes from the modular applet design.
+
+### 4. State Management (`@AppState` and State Objects)
+
+The example applets (`ExampleApplet` and `ExampleAppletInteroperability`) use the `@AppState` property wrapper to access shared data. This wrapper is provided by the `AppState` module (located in `Core/AppState`).
+
+The actual shared data structure, `ExampleAppletState`, is defined in the `ExampleAppletInterface` module (`Applets/ExampleApplet/Sources/ExampleAppletInterface/ExampleAppletState.swift`). The registration of this state with the `AppState` system (e.g., `Application.exampleAppletState`) is also typically done within this interface module.
+
+When building your application:
+
+*   **Define Your Own Shared State Objects**: If your applets need to share data, create your own Swift structs or classes to hold this data. It's good practice to define these in separate "Interface" packages (similar to `ExampleAppletInterface`) that can be imported by the applets that need them and by the `AppState` registration point.
+*   **Register State with `AppState`**: Use the mechanisms provided by the `Core/AppState` module to register your custom state objects so they can be accessed via `@AppState(\.yourCustomState)`.
+*   **Scope State**: Consider which state needs to be truly global versus local to an applet or a group of applets. Not all state needs to be in `AppState`; SwiftUI's other state management tools (`@State`, `@StateObject`, `@EnvironmentObject`, etc.) are still valuable for state that is local to a view or applet.
+
+## Core Concepts
+
+*   **`Applet` Protocol (`Core/Applet`)**: The fundamental protocol your applets must conform to. It defines the basic contract for an applet (ID, title, body view).
+*   **Modularity**: Each applet is self-contained, making it easier to develop, test, and maintain features independently.
+*   **Customizability**: The framework is a starting point. You are encouraged to change the navigation, UI presentation, and core logic to fit your specific application requirements.
+
+By following these guidelines, you can effectively fork this `AppletKit` repository and transform it into the foundation for your own modular Swift application.

--- a/Sources/AppletKit/AppletKit.swift
+++ b/Sources/AppletKit/AppletKit.swift
@@ -4,23 +4,81 @@ import ExampleApplet
 import ExampleAppletInteroperability
 import SwiftUI
 
+/// The main container view for `AppletKit`.
+///
+/// In this example implementation, `AppletKitView` uses a `TabView` to host
+/// and navigate between `ExampleApplet` and `ExampleAppletInteroperability`.
+/// The selection of tabs is managed by `AppletTab` from the `AppletNavigation` module,
+/// which is driven by shared application state (`@AppState(\.tab)`).
+///
+/// ## Customizing or Replacing `AppletKitView`
+///
+/// This view serves as the primary integration point for applets into the main application UI.
+/// Developers forking this repository will likely want to customize or entirely replace
+/// this view to suit their application's navigation and layout requirements.
+///
+/// ### Scenarios for Customization:
+///
+/// 1.  **Different Navigation**:
+///     Instead of a `TabView`, you might use a `NavigationView` with a `List`, a custom sidebar,
+///     or programmatic navigation. You would replace the `TabView` structure with your chosen
+///     SwiftUI navigation container and instantiate your custom applets within it.
+///
+/// 2.  **Integrating into an Existing App**:
+///     If `AppletKit` is being integrated into a larger, existing application, `AppletKitView`
+///     might become a sub-view within that application's hierarchy. Or, you might not use
+///     `AppletKitView` at all, instead choosing to instantiate individual applets directly
+///     where they are needed in your app's UI. Doing this would result in fractured navigation.
+///
+/// 3.  **No Applet Chrome**:
+///     If your application manages navigation externally and `AppletKit` is only used to
+///     display a single applet at a time, `AppletKitView` could be simplified to just
+///     display the currently active applet based on some state.
+///
+/// ### Steps to Customize:
+///
+/// 1.  **Modify this File**: Change the `body` of `AppletKitView` to implement your desired UI structure.
+/// 2.  **Update Navigation State**: If you change the navigation model (e.g., not using `TabView`),
+///     you may need to update or replace `Core/AppletNavigation/AppletNavigation.swift` which defines `AppletTab`.
+///     Your new view will need to manage its own navigation state.
+/// 3.  **Instantiate Your Applets**: Replace `ExampleApplet()` and `ExampleAppletInteroperability()`
+///     with instances of your own applets.
+///
+/// The key is that `AppletKitView` is flexible. Its role is to compose your applets into a cohesive
+/// user experience, whatever form that may take.
 public struct AppletKitView: View {
-    @AppState(\.tab) private var tab: AppletTab
+    /// The currently selected tab. This state is managed by `AppState` and drives the `TabView`.
+    /// If you replace `TabView`, you might replace this with a different state variable
+    /// representing your app's current navigation state.
+    @AppState(\.tab) private var tab: AppletTab // Specific to the TabView example
 
     public var body: some View {
+        // This TabView is an example. Replace it with your app's desired root navigation.
         TabView(selection: $tab) {
+            // Replace ExampleApplet with your own applets.
             ExampleApplet()
                 .tabItem {
-                    Label("Home", systemImage: "house")
+                    Label("Home (Example)", systemImage: "house")
                 }
-                .tag(AppletTab.home)
+                .tag(AppletTab.home) // AppletTab.home is part of the example navigation
 
+            // Replace ExampleAppletInteroperability with your own applets.
             ExampleAppletInteroperability()
                 .tabItem {
-                    Label("Settings", systemImage: "gear")
+                    Label("Settings (Example)", systemImage: "gear")
                 }
-                .tag(AppletTab.settings)
+                .tag(AppletTab.settings) // AppletTab.settings is part of the example navigation
         }
+        // If you don't need a TabView, your body could be as simple as:
+        // MyCustomApplet()
+        //
+        // Or a NavigationView:
+        // NavigationView {
+        //     List {
+        //         NavigationLink("My First Applet", destination: MyFirstApplet())
+        //         NavigationLink("My Second Applet", destination: MySecondApplet())
+        //     }
+        // }
     }
 }
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the `AppletKit` framework, focusing on modularity, shared state management, and improved documentation. The changes include updates to example applets, navigation state, and the project README to provide a clearer structure and customization guidance for developers.

### Updates to Example Applets

* [`Applets/ExampleApplet/Sources/ExampleApplet/ExampleApplet.swift`](diffhunk://#diff-fab005dbee8bdcb4340188ead36e153a434fb2fd0555fa580f5dd3d482ee3574R3-R19): Updated the `ExampleApplet` with improved documentation, renamed identifiers (`id` and `title`), and clarified its role as a template for creating custom applets.
* [`Applets/ExampleApplet/Sources/ExampleApplet/ExampleAppletRootView.swift`](diffhunk://#diff-28fd349f498b1a6120d03665dd262611238727c47aa3bbac8d67aae3db1f6a9bR4-R21): Enhanced documentation for the root view, added detailed comments on shared state interaction, and updated button functionality to reflect the applet's role in modifying shared state. [[1]](diffhunk://#diff-28fd349f498b1a6120d03665dd262611238727c47aa3bbac8d67aae3db1f6a9bR4-R21) [[2]](diffhunk://#diff-28fd349f498b1a6120d03665dd262611238727c47aa3bbac8d67aae3db1f6a9bR32-R58)
* [`Applets/ExampleAppletInteroperability/Sources/ExampleAppletInteroperability/ExampleAppletInteroperability.swift`](diffhunk://#diff-ac710394c261c64b7f0e1da87efc18b1eab417d38fd613739541bbbfab57381cR3-R19): Updated the `ExampleAppletInteroperability` with improved documentation and renamed identifiers, emphasizing interoperability between applets.
* [`Applets/ExampleAppletInteroperability/Sources/ExampleAppletInteroperability/ExampleAppletInteroperabilityRootView.swift`](diffhunk://#diff-ddce08794fe339f5fc3a0786293fd9eebab09f0376280453c7f7a0e26a5a78baR4-R15): Added detailed comments on shared state interaction and updated button functionality to demonstrate interoperability. [[1]](diffhunk://#diff-ddce08794fe339f5fc3a0786293fd9eebab09f0376280453c7f7a0e26a5a78baR4-R15) [[2]](diffhunk://#diff-ddce08794fe339f5fc3a0786293fd9eebab09f0376280453c7f7a0e26a5a78baR26-R39) [[3]](diffhunk://#diff-ddce08794fe339f5fc3a0786293fd9eebab09f0376280453c7f7a0e26a5a78baR48)

### Navigation State Improvements

* [`Core/AppletNavigation/Sources/AppletNavigation/AppletNavigation.swift`](diffhunk://#diff-083b35e10cd944321a357b6387f2140c7e72d0e514b1681649533460287204b3L4-R58): Replaced placeholder comments with detailed documentation for the `AppletTab` enum and its integration with shared state. This provides guidance for developers looking to customize navigation in their applets.

### Documentation Enhancements

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R165): Completely revamped the README to include an overview of the `AppletKit` framework, detailed instructions for getting started, project structure explanation, and customization guidelines for creating applets, modifying navigation, and integrating shared state.